### PR TITLE
Bump djangorestframework from 3.9.0 to 3.9.1 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=1.11,<2.0 #LTS
 django-extensions==2.1.4
 django-filter==2.0.0
 django-redis>=4.7.0,<4.8
-djangorestframework==3.9.0
+djangorestframework==3.9.1
 gunicorn==19.9.0
 ipython>=5.2.2,<5.3
 opbeat>=3.5.2,<3.6


### PR DESCRIPTION
This pull request fixes a security vulnerability by bumping  [djangorestframework](https://github.com/encode/django-rest-framework) from 3.9.0 to 3.9.1.
<details>
<summary>Release notes</summary>

*Sourced from [djangorestframework's releases](https://github.com/encode/django-rest-framework/releases).*

> ## Version 3.9.1
> Change Notes: 
>   https://www.django-rest-framework.org/community/release-notes/#39x-series
</details>
<details>
<summary>Commits</summary>

- [`453196e`](https://github.com/encode/django-rest-framework/commit/453196e9c3a581bac3bf68eb8c9cdd7d28d2dcd6) Version 3.9.1 ([#6405](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/6405))
- [`4bb9a3c`](https://github.com/encode/django-rest-framework/commit/4bb9a3c48427867ef1e46f7dee945a4c25a4f9b8) Fix XSS caused by disabled autoescaping in the default DRF Browsable API view...
- [`e3bd4b9`](https://github.com/encode/django-rest-framework/commit/e3bd4b90488bab756694ce271a9615460783f987) Fix [#1811](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/1811): take limit_choices_to into account with FK ([#6371](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/6371))
- [`9c408b2`](https://github.com/encode/django-rest-framework/commit/9c408b296b65ea14173de69139218afc97e158b3) Remove reference to deprecated drf-openapi package ([#6398](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/6398))
- [`e0ae975`](https://github.com/encode/django-rest-framework/commit/e0ae975e5c543c16f0330cc4acda9387d25fee74) Fix a badly formatted title in docs ([#6089](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/6089))
- [`c052a86`](https://github.com/encode/django-rest-framework/commit/c052a86c7b8ebc8159582dafaea3f6cf4a8c40f5) compat: (py2) urlparse = urllib.parse (py3) ([#6262](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/6262))
- [`a49d744`](https://github.com/encode/django-rest-framework/commit/a49d744d5ee84ae2e89abde30ceddd2463e1f676) Fix OpenAPI links ([#6382](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/6382))
- [`0860ef9`](https://github.com/encode/django-rest-framework/commit/0860ef9eeebf77e1780b0d86b3fdf01f5aaa5cc3) Update quickstart to Django 2.0 routing syntax ([#6385](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/6385))
- [`587058e`](https://github.com/encode/django-rest-framework/commit/587058e3c25aac4d871828a3ef19637eb9e8ddbd) Allow run_validators() to handle non-dict types. ([#6365](https://github-redirect.dependabot.com/encode/django-rest-framework/issues/6365))
- [`0cf18c4`](https://github.com/encode/django-rest-framework/commit/0cf18c41631a1e2ee6013a58c7b9bbdb9d8bd8e4) Use Default Version in URLPathVersioning if 'version' Didn't Specified by Cli...
- Additional commits viewable in [compare view](https://github.com/encode/django-rest-framework/compare/3.9.0...3.9.1)
</details>

We depend on this in sensors.AFRICA-api https://github.com/CodeForAfrica/sensors.AFRICA-api/pull/45

cc @ricki-z 