### PR TITLE
[Chore] Allow upgrading django-filters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=1.11,<2.0 #LTS
 django-extensions==2.1.4
-django-filter==2.0.0
+django-filter>=2.0.0,<3.0
 django-redis>=4.7.0,<4.8
 djangorestframework==3.9.1
 gunicorn==19.9.0


### PR DESCRIPTION
Allow upgrading `django-filters` to use recent features such as [`IsoDateTimeFromToRangeFilter`](https://github.com/carltongibson/django-filter/blob/master/CHANGES.rst#version-21-2019-1-20)
